### PR TITLE
Hack corefile configmap

### DIFF
--- a/scripts/master.cfg.tpl
+++ b/scripts/master.cfg.tpl
@@ -202,6 +202,34 @@ write_files:
     owner: root:root
     permissions: '0600'
 -   content: |
+        apiVersion: v1
+        data:
+          Corefile: |
+            .:53 {
+                errors
+                health {
+                  lameduck 5s
+                }
+                ready
+                kubernetes cluster.local in-addr.arpa ip6.arpa {
+                  pods insecure
+                  fallthrough in-addr.arpa ip6.arpa
+                  ttl 30
+                }
+                prometheus :9153
+                forward . 8.8.8.8 {
+                  max_concurrent 1000
+                }
+                cache 30
+                loop
+                reload
+                loadbalance
+            }
+        kind: ConfigMap
+    path: /etc/kubernetes/addons/coredns-hack.yaml
+    owner: root:root
+    permissions: '0600'
+-   content: |
         #!/bin/bash
         set -eu
 
@@ -228,7 +256,7 @@ write_files:
         export KUBECONFIG=/etc/kubernetes/admin.conf
         kubectl apply -f "https://docs.projectcalico.org/archive/v3.15/manifests/calico.yaml"
 
-        # kubectl apply -n kube-system  -f "/etc/kubernetes/addons"
+        kubectl apply -n kube-system  -f "/etc/kubernetes/addons"
         # Install Metrics Server
         # kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.4.1/components.yaml
 


### PR DESCRIPTION
To resolve name resolving loop, replace /etc/resolv.conf with
8.8.8.8. This is because the openstack instance has 127.0.0.1:53
nameserver.